### PR TITLE
add test for description event

### DIFF
--- a/workitem/event/event_repository_blackbox_test.go
+++ b/workitem/event/event_repository_blackbox_test.go
@@ -110,8 +110,8 @@ func (s *eventRepoBlackBoxTest) TestList() {
 		require.NoError(t, err)
 		require.NotEmpty(t, eventList)
 		require.Len(t, eventList, 1)
-		require.Empty(t, eventList[0].Old)
-		require.Empty(t, eventList[0].New)
+		require.Equal(t, "description1", eventList[0].Old)
+		require.Equal(t, "description2", eventList[0].New)
 		require.Equal(t, wiNew.Fields[workitem.SystemDescription], newDescription)
 	})
 


### PR DESCRIPTION
This PR adds a test for `description events`

@baijum Please merge this PR and you'll see why the API is failing on minishift (it has nothing to do with minishift).

It's failing at https://github.com/fabric8-services/fabric8-wit/pull/1959/files#diff-64c8a1eca0152efc499d40c8cac570b7R137 when it tries to compare two `map[string]interface{}` that is `map[markup:.. content:..]` and `map[markup:.. content:..]`

**NOTE** - Merging this PR with break your tests (for good)